### PR TITLE
ENH: add Parquet IO

### DIFF
--- a/dask_geopandas/__init__.py
+++ b/dask_geopandas/__init__.py
@@ -8,6 +8,8 @@ from .core import (
     from_geopandas,
     from_dask_dataframe,
 )
+from .io.parquet import read_parquet, to_parquet
+
 
 __version__ = get_versions()["version"]
 del get_versions
@@ -18,4 +20,6 @@ __all__ = [
     "GeoSeries",
     "from_geopandas",
     "from_dask_dataframe",
+    "read_parquet",
+    "to_parquet"
 ]

--- a/dask_geopandas/io/parquet.py
+++ b/dask_geopandas/io/parquet.py
@@ -1,0 +1,49 @@
+from functools import partial
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+import geopandas
+from geopandas.io.arrow import _geopandas_to_arrow, _arrow_to_geopandas
+
+import dask.dataframe as dd
+from dask.dataframe.io.parquet.arrow import ArrowEngine
+
+if TYPE_CHECKING:
+    import pyarrow
+
+
+class GeoArrowEngine(ArrowEngine):
+
+    @classmethod
+    def read_metadata(cls, *args, **kwargs):
+        meta, stats, parts, index = super().read_metadata(*args, **kwargs)
+
+        # Update meta to be a GeoDataFrame
+        # TODO convert columns based on GEO metadata (this will now only work for a default "geometry" column)
+        meta = geopandas.GeoDataFrame(meta)
+
+        return (meta, stats, parts, index)
+
+    @classmethod
+    def _arrow_table_to_pandas(
+        cls, arrow_table: "pyarrow.Table", categories, **kwargs
+    ) -> pd.DataFrame:
+        _kwargs = kwargs.get("arrow_to_pandas", {})
+        _kwargs.update({"use_threads": False, "ignore_metadata": False})
+
+        # TODO support additional keywords
+        return _arrow_to_geopandas(arrow_table)
+
+    @classmethod
+    def _pandas_to_arrow_table(
+        cls, df: pd.DataFrame, preserve_index=False, schema=None
+    ) -> "pyarrow.Table":
+        # TODO add support for schema
+        table = _geopandas_to_arrow(df, index=preserve_index)
+        # table = pa.Table.from_pandas(df, preserve_index=preserve_index, schema=schema)
+        return table
+
+
+to_parquet = partial(dd.to_parquet, engine=GeoArrowEngine)
+read_parquet = partial(dd.read_parquet, engine=GeoArrowEngine)


### PR DESCRIPTION
Addressing the Parquet IO part of https://github.com/jsignell/dask-geopandas/issues/6

For now this is heavily reusing dask's Parquet machinery, which is easy thanks to the Engine classes (I don't know if this will keep being possible long term, though, if we want to add more customizations, eg related to spatial partitioning etc ..)

(still need to add tests, but this is working nicely for basic example!)